### PR TITLE
Fixes #12 and #13 return value if not-found in get

### DIFF
--- a/src/com/tbaldridge/odin/unification.clj
+++ b/src/com/tbaldridge/odin/unification.clj
@@ -32,10 +32,13 @@
 (defn lvar? [x]
   (instance? LVar x))
 
+(def not-found (gensym))
+
 (defn walk [env a]
-  (if-let [a (get env a)]
-    (recur env a)
-    a))
+  (let [b (get env a not-found)]
+    (if (identical? b not-found)
+      a
+      (recur env b))))
 
 (defmulti -unify (fn [env a b]
                    [(type a) (type b)]))
@@ -57,6 +60,14 @@
 (defmethod -unify [LVar LVar]
   [env a b]
   (assoc env a b))
+
+(defmethod -unify [LVar nil]
+  [env a b]
+  (assoc env a b))
+
+(defmethod -unify [nil LVar]
+  [env a b]
+  (assoc env b a))
 
 
 (defn unify

--- a/test/com/tbaldridge/odin_test.clj
+++ b/test/com/tbaldridge/odin_test.clj
@@ -32,6 +32,27 @@
                     (d/query data _ ?a _)
                     #{:a :b :c :d :e :f :g})))))))
 
+(deftest false-in-data
+  (let [data [1 2 3 false]]
+    (is (= (set (o/for-query
+                  (d/query data _ _ ?val)
+                  ?val))
+            (set data)))))
+
+(deftest nil-in-data
+  (let [data [1 2 3 nil]]
+    (is (= (set (o/for-query
+                  (d/query data ?path _ ?val)
+                  ?val))
+            (set [1 2 3])))
+
+    (is (= (set (o/for-query
+                  (d/query data ?path _ ?val)
+                  [?val]))
+            (->> data 
+              (map vector)
+              set)))))
+
 (o/defrule parent [data ?parent ?child]
   (o/and
     (d/query data ?cid :name ?child)


### PR DESCRIPTION
Added extra defmethods to replace nil value in `-unify` with a special `gensym`.

Added a step just where the reducible value is passed to `with-env` to replace the special `gensym` with nil.

These in effect wrap and un-wrap nil values in the data set.

