### PR TITLE
Add support for seq from o/for-query

### DIFF
--- a/src/com/tbaldridge/odin/unification.clj
+++ b/src/com/tbaldridge/odin/unification.clj
@@ -104,12 +104,18 @@
 (defn with-env [reducible]
   (let [ctx *query-ctx*]
     (reify
+
+      Iterable
+      (iterator [_]
+        (binding [*query-ctx* (or *query-ctx* ctx)]
+           (.iterator reducible)))
+
       clojure.lang.IReduceInit
       (reduce [this f init]
-        (if *query-ctx*
-          (reduce f init reducible)
-          (binding [*query-ctx* ctx]
-            (reduce f init reducible)))))))
+        (binding [*query-ctx* (or *query-ctx* ctx)]
+           (reduce f init reducible)))
+
+      clojure.lang.Sequential)))
 
 (defn for-query-impl [query projection]
   (let [[query-lvars query-form] (body-lvars query)

--- a/test/com/tbaldridge/odin_test.clj
+++ b/test/com/tbaldridge/odin_test.clj
@@ -32,6 +32,13 @@
                     (d/query data _ ?a _)
                     #{:a :b :c :d :e :f :g})))))))
 
+(deftest seq-query
+  (let [data [1 2 3]]
+    (is (= (seq (o/for-query 
+                  (d/query data _ _ ?val)
+                  ?val))
+            (seq [1 2 3])))))
+
 (o/defrule parent [data ?parent ?child]
   (o/and
     (d/query data ?cid :name ?child)


### PR DESCRIPTION
Allow support for `seq` and friends on `for-query` without having to convert to `vec` or `set` first. 