### PR TITLE
bump to clojure 1.9.0-beta1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://github.com/halgari/odin"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha13"]
+  :dependencies [[org.clojure/clojure "1.9.0-beta1"]
                  [org.clojure/clojurescript "1.9.293"]
                  [org.clojure/test.check "0.9.0"]]
   ;:jvm-opts ["-agentpath:/Users/tim/lib/libyjpagent.jnilib"]

--- a/src/com/tbaldridge/odin/contexts/spec.clj
+++ b/src/com/tbaldridge/odin/contexts/spec.clj
@@ -1,5 +1,5 @@
 (ns com.tbaldridge.odin.contexts.spec
-  (:require [clojure.spec :as s]
+  (:require [clojure.spec.alpha :as s]
             [com.tbaldridge.odin.contexts.data :as d]
             [com.tbaldridge.odin :as o]))
 

--- a/src/com/tbaldridge/odin/unification.clj
+++ b/src/com/tbaldridge/odin/unification.clj
@@ -3,7 +3,7 @@
   (:require [clojure.walk :as walk]
             [clojure.string :as str]
             [clojure.set :as set]
-            [clojure.spec :as s]
+            [clojure.spec.alpha :as s]
             [com.tbaldridge.odin.util :refer [body-lvars]]
             [com.tbaldridge.odin.util :as util])
     (:import (java.io Writer)))

--- a/test/com/tbaldridge/contexts/spec_test.clj
+++ b/test/com/tbaldridge/contexts/spec_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer [deftest is]]
             [com.tbaldridge.odin :as o]
             [com.tbaldridge.odin.contexts.spec :as sc]
-            [clojure.spec :as s]))
+            [clojure.spec.alpha :as s]))
 
 
 (s/def ::some-int integer?)


### PR DESCRIPTION
bump dependencies and track changes to clojure.spec namespace change to clojure.spec.alpha