### PR TITLE
2018patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ to modify, so `o/transform` uses the location specified by `o/update` to specify
 
 
 ```clojure
-(o/transform query-that-contains-update-clause
+(o/transform data query-that-contains-update-clause
    f & args-for-f)
 ```       
            

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ that any query parameter that is specified using `_` is interpreted as a wildcar
 
 (into {}
   (o/for-query
-    (o/query data _ _ ?val)
+    (d/query data _ _ ?val)
     [?val (* ?val ?val)]))
     
 ;; => {1 1

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ An embedded extensible logic programming DSL for CLojure
 Add the following to your lein deps:
 
 ```clojure
-[org.clojure/clojure "1.9.0-alpha14"]
-[com.tbaldridge/odin "0.2.0"]
+[org.clojure/clojure "1.9.0"]
+[com.tbaldridge/odin "0.3.1-SNAPSHOT"]
 ```
 
 
@@ -142,6 +142,7 @@ specifies the negative balance of the account.
 
 ```clojure
 (o/transform
+    data
     (o/and
       (d/query data ?account :credits ?credits)
       (d/query data ?account :debits ?debits)

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject com.tbaldridge/odin "0.3.0-SNAPSHOT"
+(defproject com.tbaldridge/odin "0.3.1-SNAPSHOT"
   :description "A declarative query DSL for Clojure"
   :url "http://github.com/halgari/odin"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha13"]
-                 [org.clojure/clojurescript "1.9.293"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/clojurescript "1.9.946"]
                  [org.clojure/test.check "0.9.0"]]
   ;:jvm-opts ["-agentpath:/Users/tim/lib/libyjpagent.jnilib"]
   :profiles {:dev {:dependencies [[org.clojure/data.xml "0.0.8"]

--- a/src/com/tbaldridge/odin.clj
+++ b/src/com/tbaldridge/odin.clj
@@ -112,8 +112,7 @@
 
 (defn update
   ([?path]
-    (==
-      ?path u/xform-path))
+    (= ?path u/xform-path))
   ([?path ?attr]
     (and
       (= ?path u/xform-path)

--- a/src/com/tbaldridge/odin/contexts/spec.clj
+++ b/src/com/tbaldridge/odin/contexts/spec.clj
@@ -78,7 +78,28 @@
 (s/unform ::spec (s/conform ::spec `(s/keys :req [::foo ::bar])))
 (s/conform ::spec `(s/keys :req [::foo ::bar]))
 
+;;(def frm
+;; (clojure.spec.alpha/and clojure.core/simple-symbol?
+;;    (clojure.core/fn [%] (clojure.core/not= (quote &) %)))))
 
+;;(s/conform :com.tbaldridge.odin.contexts.spec/spec  frm)
+;;this fails us
+
+;; Testing com.tbaldridge.contexts.spec-test
+;; :clojure.core.specs.alpha/local-name ->  :clojure.spec.alpha/invalid
+
+;; Couldn't conform  :clojure.core.specs.alpha/local-name
+;; (clojure.spec.alpha/and
+;;  clojure.core/simple-symbol? (clojure.core/fn [%]
+;;                                (clojure.core/not= (quote &) %)))
+
+
+;;this is just scanning through the registry, looking for
+;;specs that we've defined as compatible with
+;;odin's notion of specs.  Many if of the specs will
+;;print out nonconformity errors, so you get a lot of
+;;noise.  During testing it looks like things fail,
+;;but they don't.
 (defn spec-forms []
   (o/cache-in-context ::specs
     (let [registry (s/registry)]
@@ -91,6 +112,8 @@
                                          (s/conform ::spec))]
                          (println k "-> " result)
                          (if (s/invalid? result)
+                           ;;recommend changing this to be optional or silent.
+                           ;;many registered specs don't conform, it's okay.
                            (println "Couldn't conform " k " " (s/form spec))
                            result)))))))))
 

--- a/src/com/tbaldridge/odin/contexts/spec.clj
+++ b/src/com/tbaldridge/odin/contexts/spec.clj
@@ -1,5 +1,5 @@
 (ns com.tbaldridge.odin.contexts.spec
-  (:require [clojure.spec :as s]
+  (:require [clojure.spec.alpha :as s]
             [com.tbaldridge.odin.contexts.data :as d]
             [com.tbaldridge.odin :as o]))
 

--- a/src/com/tbaldridge/odin/unification.clj
+++ b/src/com/tbaldridge/odin/unification.clj
@@ -3,7 +3,7 @@
   (:require [clojure.walk :as walk]
             [clojure.string :as str]
             [clojure.set :as set]
-            [clojure.spec :as s]
+            [clojure.spec.alpha :as s]
             [com.tbaldridge.odin.util :refer [body-lvars]]
             [com.tbaldridge.odin.util :as util])
     (:import (java.io Writer)))

--- a/test/com/tbaldridge/contexts/spec_test.clj
+++ b/test/com/tbaldridge/contexts/spec_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer [deftest is]]
             [com.tbaldridge.odin :as o]
             [com.tbaldridge.odin.contexts.spec :as sc]
-            [clojure.spec :as s]))
+            [clojure.spec.alpha :as s]))
 
 
 (s/def ::some-int integer?)

--- a/test/com/tbaldridge/contexts/spec_test.clj
+++ b/test/com/tbaldridge/contexts/spec_test.clj
@@ -14,7 +14,13 @@
 
 (s/def ::map (s/keys :req [::some-int ::some-float]))
 
-
+;;Note: getting a lot of printing about spec
+;;non-conforming is fine, it's an artifact of
+;;odin scanning all the registered specs and
+;;checking for conformity against its notion
+;;of permissible specs.  Many core specs will
+;;fail to conform, and be printed to std out.
+;;Tests still pass.
 (deftest basic-resolution-tests
   (is (= (set (o/for-query
                 (o/and


### PR DESCRIPTION
Dusted off to provide a version compatible with clojure 1.9.  Some of the published features from 2016 no longer work.  This fork changes all spec references to spec.alpha .  Additionally, the examples in the readme are fixed to reflect the actual argument invocations in source.  I ran into a spot during test with tons of non-conforming spec output, but after tracking it down determined it was as intended.  Annotated the source where and why the output occurs in case anyone else runs into it.